### PR TITLE
Remove inner entity_registry import

### DIFF
--- a/custom_components/vacasa/binary_sensor.py
+++ b/custom_components/vacasa/binary_sensor.py
@@ -319,7 +319,6 @@ class VacasaOccupancySensor(BinarySensorEntity):
                 )
 
                 # Add additional debugging info only if needed
-                from homeassistant.helpers import entity_registry as er
 
                 try:
                     registry = er.async_get(self.hass)


### PR DESCRIPTION
## Summary
- refactor Vacasa binary sensor to remove inner import

## Testing
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_688a87891bec832a9a01ab2b07baa459