### PR TITLE
Adjust sensor retry wait time

### DIFF
--- a/custom_components/vacasa/binary_sensor.py
+++ b/custom_components/vacasa/binary_sensor.py
@@ -207,7 +207,8 @@ class VacasaOccupancySensor(BinarySensorEntity):
                 return entity_id
 
             if attempt < max_retries - 1:
-                wait_time = 2**attempt  # 2s, 4s, 8s
+                # Exponential backoff: wait 2s, 4s, 8s between retries
+                wait_time = 2 ** (attempt + 1)
                 _LOGGER.debug(
                     "Calendar entity not found for unit %s, retrying in %ss (attempt %d/%d)",
                     self._unit_id,

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,0 +1,63 @@
+"""Tests for Vacasa binary sensor retry logic."""
+
+from unittest.mock import AsyncMock, Mock, call, patch
+
+import pytest
+
+from custom_components.vacasa.binary_sensor import VacasaOccupancySensor
+
+
+class TestBinarySensorRetry:
+    """Test retry behavior when locating calendar entity."""
+
+    @pytest.mark.asyncio
+    async def test_find_calendar_entity_with_retry_success(self):
+        """Calendar entity found after retries with expected backoff."""
+        sensor = VacasaOccupancySensor(
+            coordinator=Mock(),
+            client=Mock(),
+            unit_id="unit123",
+            name="Test Unit",
+            code="TU",
+            unit_attributes={},
+        )
+
+        with (
+            patch.object(
+                sensor,
+                "_find_calendar_entity",
+                side_effect=[None, None, "calendar.test"],
+            ),
+            patch(
+                "custom_components.vacasa.binary_sensor.asyncio.sleep",
+                new=AsyncMock(),
+            ) as mock_sleep,
+        ):
+            result = await sensor._find_calendar_entity_with_retry(max_retries=3)
+
+            assert result == "calendar.test"
+            mock_sleep.assert_has_awaits([call(2), call(4)])
+
+    @pytest.mark.asyncio
+    async def test_find_calendar_entity_with_retry_failure(self):
+        """Calendar entity not found after max retries."""
+        sensor = VacasaOccupancySensor(
+            coordinator=Mock(),
+            client=Mock(),
+            unit_id="unit123",
+            name="Test Unit",
+            code="TU",
+            unit_attributes={},
+        )
+
+        with (
+            patch.object(sensor, "_find_calendar_entity", return_value=None),
+            patch(
+                "custom_components.vacasa.binary_sensor.asyncio.sleep",
+                new=AsyncMock(),
+            ) as mock_sleep,
+        ):
+            result = await sensor._find_calendar_entity_with_retry(max_retries=3)
+
+            assert result is None
+            mock_sleep.assert_has_awaits([call(2), call(4)])


### PR DESCRIPTION
## Summary
- fix backoff math for calendar lookup retries
- test the binary sensor retry delays

## Testing
- `pre-commit run --files custom_components/vacasa/binary_sensor.py tests/test_binary_sensor.py`
- `PYTHONPATH=. pytest tests/test_binary_sensor.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688a877dd3b0832a8ae1889353055354