### PR TITLE
Remove unused cache attributes

### DIFF
--- a/custom_components/vacasa/api_client.py
+++ b/custom_components/vacasa/api_client.py
@@ -139,9 +139,6 @@ class VacasaApiClient:
             max_jitter=jitter_max,
         )
 
-        # Track cached unit details to avoid redundant API calls
-        self._cached_units: list[dict[str, Any]] | None = None
-        self._units_cache_time: float | None = None
 
         _LOGGER.debug(
             "Initialized Vacasa API client with cache TTL: %s, max connections: %s",


### PR DESCRIPTION
## Summary
- drop `_cached_units` and `_units_cache_time` from `VacasaApiClient`
- run tests

## Testing
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_688a8772a6b4832a9d0f9d2245c38b0e