### PR TITLE
Use urlencode in Vacasa API client

### DIFF
--- a/custom_components/vacasa/api_client.py
+++ b/custom_components/vacasa/api_client.py
@@ -1,6 +1,7 @@
 """API client for the Vacasa integration."""
 
 import asyncio
+import base64
 import json
 import logging
 import os
@@ -8,9 +9,9 @@ import re
 import time
 from datetime import datetime, timedelta, timezone
 from typing import Any
+from urllib.parse import urlencode
 
 import aiohttp
-import base64
 
 from .cached_data import CachedData, RetryWithBackoff
 from .const import (
@@ -139,7 +140,6 @@ class VacasaApiClient:
             backoff_multiplier=RETRY_BACKOFF_MULTIPLIER,
             max_jitter=jitter_max,
         )
-
 
         _LOGGER.debug(
             "Initialized Vacasa API client with cache TTL: %s, max connections: %s",
@@ -373,7 +373,7 @@ class VacasaApiClient:
         Returns:
             Formatted parameters string
         """
-        return "&".join([f"{k}={v}" for k, v in params.items()])
+        return urlencode(params)
 
     def _base64_url_decode(self, input: str) -> str:
         """Decode base64url-encoded string.
@@ -494,7 +494,7 @@ class VacasaApiClient:
                 _LOGGER.debug(
                     "Auth URL with params: %s?%s",
                     AUTH_URL,
-                    "&".join([f"{k}={v}" for k, v in auth_params.items()]),
+                    self._format_params(auth_params),
                 )
 
                 async with session.get(

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,6 +1,7 @@
 """Unit tests for the Vacasa API client."""
 
 import json
+import urllib.parse
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, Mock, mock_open, patch
 
@@ -737,9 +738,21 @@ class TestApiResponseParsing:
         params = {"key1": "value1", "key2": "value2"}
         result = api_client._format_params(params)
 
-        assert "key1=value1" in result
-        assert "key2=value2" in result
-        assert "&" in result
+        parsed = dict(urllib.parse.parse_qsl(result))
+        assert parsed == params
+
+    def test_format_params_special_characters(self, api_client):
+        """Test parameter formatting with special characters."""
+        params = {
+            "spaced key": "value with spaces",
+            "amp": "a&b",
+            "equals": "x=y",
+        }
+
+        result = api_client._format_params(params)
+        parsed = dict(urllib.parse.parse_qsl(result))
+
+        assert parsed == params
 
     def test_base64_url_decode(self, api_client):
         """Test _base64_url_decode utility method."""


### PR DESCRIPTION
## Summary
- rely on urllib.parse.urlencode for param handling
- update debug log to reuse `_format_params`
- test formatting of special characters

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'homeassistant.components')*
- `pip install homeassistant==2024.6.1` *(fails: version requires different python version)*

------
https://chatgpt.com/codex/tasks/task_e_688aa2ec4da4832a813bd438a2875918