### PR TITLE
Fix ConfigEntry stub and options flow test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,12 +11,12 @@ config_entries = types.ModuleType("homeassistant.config_entries")
 
 
 class ConfigEntry:
-    """Simplified ConfigEntry stub."""
+    """Simplified ConfigEntry stub matching Home Assistant."""
 
-    def __init__(self, data=None, options=None, hass=None):
+    def __init__(self, data=None, options=None):
         self.data = data or {}
         self.options = options or {}
-        self.hass = hass
+        self.hass = None
 
 
 class OptionsFlow:
@@ -72,6 +72,36 @@ exceptions.ConfigEntryNotReady = ConfigEntryNotReady
 helpers = types.ModuleType("homeassistant.helpers")
 aiohttp_client = types.ModuleType("homeassistant.helpers.aiohttp_client")
 update_coordinator = types.ModuleType("homeassistant.helpers.update_coordinator")
+entity_platform = types.ModuleType("homeassistant.helpers.entity_platform")
+entity_registry = types.ModuleType("homeassistant.helpers.entity_registry")
+util = types.ModuleType("homeassistant.util")
+dt_util = types.ModuleType("homeassistant.util.dt")
+components = types.ModuleType("homeassistant.components")
+components_binary_sensor = types.ModuleType("homeassistant.components.binary_sensor")
+
+
+class BinarySensorEntity:
+    async def async_added_to_hass(self):
+        return None
+
+    async def async_will_remove_from_hass(self):
+        return None
+
+    def async_write_ha_state(self):
+        return None
+
+
+class BinarySensorDeviceClass:
+    OCCUPANCY = "occupancy"
+
+
+components_binary_sensor.BinarySensorEntity = BinarySensorEntity
+components_binary_sensor.BinarySensorDeviceClass = BinarySensorDeviceClass
+
+entity_platform.AddEntitiesCallback = None
+entity_registry.async_get = lambda hass: types.SimpleNamespace(entities={})
+dt_util.parse_datetime = lambda s: datetime.fromisoformat(s)
+util.dt = dt_util
 
 
 async def async_get_clientsession(hass):
@@ -115,6 +145,12 @@ modules = {
     "homeassistant.helpers": helpers,
     "homeassistant.helpers.aiohttp_client": aiohttp_client,
     "homeassistant.helpers.update_coordinator": update_coordinator,
+    "homeassistant.helpers.entity_platform": entity_platform,
+    "homeassistant.helpers.entity_registry": entity_registry,
+    "homeassistant.util": util,
+    "homeassistant.util.dt": dt_util,
+    "homeassistant.components": components,
+    "homeassistant.components.binary_sensor": components_binary_sensor,
     "homeassistant.data_entry_flow": data_entry_flow,
 }
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,13 +1,13 @@
 """Tests for the Vacasa configuration flow."""
 
-from homeassistant.config_entries import ConfigEntry
+from types import SimpleNamespace
 from custom_components.vacasa.config_flow import VacasaOptionsFlowHandler
 
 
 def test_options_flow_initializes_base_class():
     """Ensure the options flow handler initializes its base class."""
 
-    entry = ConfigEntry(hass="hass")
+    entry = SimpleNamespace(hass="hass")
     handler = VacasaOptionsFlowHandler(entry)
     assert handler.config_entry is entry
     assert handler.hass == "hass"


### PR DESCRIPTION
## Summary
- update `ConfigEntry` stub to match Home Assistant
- adjust the options flow unit test to avoid requiring Home Assistant
- add more stub modules for binary sensor tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688aa2eea7dc832a9c14ba31c262cd76