### PR TITLE
Add missing runtime dependencies

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,4 @@
+# Testing dependencies
+pytest>=8.0.0
+pytest-asyncio>=0.23
+pytest-homeassistant-custom-component>=0.0.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ types-setuptools>=65.0.0
 
 # Runtime dependencies
 aiohttp>=3.8.0
+async_timeout>=4.0.0
+voluptuous>=0.13


### PR DESCRIPTION
## Summary
- include runtime libraries in `requirements.txt`
- add `requirements-test.txt` for pytest deps

## Testing
- `pytest tests/test_api_client.py::TestVacasaApiClient::test_init_with_defaults -q`

------
https://chatgpt.com/codex/tasks/task_e_688aa2d0fa20832ab36963ae533e56f8