### PR TITLE
Add automatic release workflow

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -1,0 +1,191 @@
+name: Auto Release on Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  validate-release:
+    runs-on: ubuntu-latest
+    name: Validate Release
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install homeassistant
+          pip install -r requirements.txt
+
+      - name: Validate version consistency
+        run: |
+          python <<'PY'
+          import json, sys
+          with open('custom_components/vacasa/manifest.json') as f:
+              manifest = json.load(f)
+          version = manifest.get('version', '')
+          with open('VERSION') as vf:
+              file_version = vf.read().strip()
+          if version != file_version:
+              print(f"Version mismatch: manifest={version}, VERSION file={file_version}")
+              sys.exit(1)
+          print(f"Version validation passed: {version}")
+          PY
+      - name: Validate HACS requirements
+        uses: hacs/action@main
+        with:
+          category: integration
+          ignore: brands
+
+  create-release:
+    runs-on: ubuntu-latest
+    name: Create Release
+    needs: validate-release
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Get version
+        id: version
+        run: |
+          VERSION=$(cat VERSION)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+      - name: Create release tag
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git tag -a ${{ steps.version.outputs.tag }} -m "Release ${{ steps.version.outputs.tag }}"
+          git push origin ${{ steps.version.outputs.tag }}
+      - name: Generate changelog
+        id: changelog
+        run: |
+          python -c "
+          import json
+          import subprocess
+          import sys
+
+          # Try to get changelog from CHANGELOG.md
+          changelog_content = ''
+          try:
+              with open('CHANGELOG.md', 'r') as f:
+                  content = f.read()
+
+              # Extract section for current version
+              version = '${{ steps.version.outputs.version }}'
+              lines = content.split('\n')
+              in_version_section = False
+              for line in lines:
+                  if line.startswith('## ') and version in line:
+                      in_version_section = True
+                      continue
+                  elif line.startswith('## ') and in_version_section:
+                      break
+                  elif in_version_section:
+                      changelog_content += line + '\n'
+          except FileNotFoundError:
+              pass
+
+          # If no changelog found, generate from git commits
+          if not changelog_content.strip():
+              try:
+                  # Get commits since last tag
+                  result = subprocess.run(
+                      ['git', 'log', '--oneline', '--pretty=format:- %s', 'HEAD...HEAD~10'],
+                      capture_output=True, text=True
+                  )
+                  if result.returncode == 0:
+                      changelog_content = result.stdout
+              except Exception:
+                  changelog_content = 'See commit history for changes.'
+
+          # Save changelog to file
+          with open('release_notes.txt', 'w') as f:
+              f.write(changelog_content)
+
+          print(f'Generated changelog for version ${{ steps.version.outputs.version }}')
+          "
+
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.version.outputs.tag }}
+          name: Release ${{ steps.version.outputs.tag }}
+          bodyFile: release_notes.txt
+          draft: false
+          prerelease: false
+          generateReleaseNotes: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create release archive
+        run: |
+          mkdir -p release/custom_components
+          cp -r custom_components/vacasa release/custom_components/
+          cd release
+          zip -r ../vacasa-${{ steps.version.outputs.version }}.zip .
+          cd ..
+
+      - name: Upload release archive
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.version.outputs.tag }}
+          artifacts: "vacasa-${{ steps.version.outputs.version }}.zip"
+          allowUpdates: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  notify-hacs:
+    runs-on: ubuntu-latest
+    name: Notify HACS
+    needs: create-release
+    if: success()
+    steps:
+      - name: Wait for release
+        run: sleep 30
+
+      - name: Notify users
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const version = '${{ steps.version.outputs.version }}';
+            const body = `
+            ## 🎉 New Release Available: v${version}
+
+            A new version of the Vacasa integration has been released!
+
+            **Installation via HACS:**
+            1. Go to HACS > Integrations
+            2. Find "Vacasa" in your installed integrations
+            3. Click "Update" when available
+
+            **Manual Installation:**
+            1. Download the \`vacasa-${version}.zip\` from the [releases page](https://github.com/${{ github.repository }}/releases/latest)
+            2. Extract to your \`custom_components\` directory
+            3. Restart Home Assistant
+
+            **What's New:**
+            Check the [release notes](https://github.com/${{ github.repository }}/releases/tag/v${version}) for detailed changes.
+
+            **Need Help?**
+            - [Documentation](https://github.com/${{ github.repository }}/blob/main/README.md)
+            - [Report Issues](https://github.com/${{ github.repository }}/issues)
+            - [Discussions](https://github.com/${{ github.repository }}/discussions)
+            `;
+
+            // This could be used to create a discussion post about the release
+            console.log('Release notification prepared');


### PR DESCRIPTION
## Summary
- create GitHub workflow that tags the latest commit and publishes a release whenever a PR merges into `main`

## Testing
- `pre-commit run --files .github/workflows/auto_release.yml`
- `pytest -q` *(fails: async framework plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_688b9d445628832aaf33f8777f36d870