### PR TITLE
fix: grant permissions for dependency PR workflow

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -9,6 +9,10 @@ on:
       - "requirements.txt"
       - "custom_components/vacasa/manifest.json"
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   check-dependencies:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- ensure dependency update workflow has required write permissions

## Testing
- `pre-commit run --files .github/workflows/dependencies.yml`
- `pytest` *(fails: Unknown config option: asyncio_mode)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0a495b3c832aa2a2baee94bd69a7