### PR TITLE
fix: grant permissions for dependency workflow

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -138,6 +138,9 @@ jobs:
   create-dependency-update-pr:
     runs-on: ubuntu-latest
     name: Create Dependency Update PR
+    permissions:
+      contents: write
+      pull-requests: write
     if: github.event_name == 'schedule'
     needs: [check-dependencies, validate-manifest-dependencies, check-homeassistant-compatibility]
     steps:


### PR DESCRIPTION
## Summary
- ensure dependency update workflow can push branches by granting write permissions for contents and pull requests

## Testing
- `pre-commit run --files .github/workflows/dependencies.yml`
- `pytest` *(fails: Unknown config option: asyncio_mode; ImportError for homeassistant modules)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0a495b3c832aa2a2baee94bd69a7