### PR TITLE
fix: harden sensor null-handling and restore failing test stubs

### DIFF
--- a/custom_components/vacasa/sensor.py
+++ b/custom_components/vacasa/sensor.py
@@ -278,12 +278,16 @@ class VacasaBedroomsSensor(VacasaBaseSensor):
     def __init__(self, **kwargs: Any) -> None:
         """Pre-compute bedroom count and bed-type attributes from immutable unit_attributes."""
         super().__init__(**kwargs)
-        amenities = self._unit_attributes.get("amenities", {})
-        rooms = amenities.get("rooms", {})
-        self._bedrooms: int | None = rooms.get("bedrooms") if rooms else None
+        # `dict.get(key, default)` returns the default only when the key is missing,
+        # not when the value is explicitly None. Coerce None to {} so the chained
+        # lookups below cannot raise on `None.get(...)`.
+        amenities = self._unit_attributes.get("amenities") or {}
+        rooms = amenities.get("rooms") or {}
+        beds = amenities.get("beds") or {}
+        self._bedrooms: int | None = rooms.get("bedrooms")
         self._bed_attrs: dict[str, Any] = {
             f"{bed_type}_beds": count
-            for bed_type, count in amenities.get("beds", {}).items()
+            for bed_type, count in beds.items()
             if count and bed_type != "child"  # Skip child beds as they're not real beds
         }
 
@@ -309,7 +313,11 @@ class VacasaBathroomsSensor(VacasaBaseSensor):
     def __init__(self, **kwargs: Any) -> None:
         """Pre-compute bathroom value and attributes from immutable unit_attributes."""
         super().__init__(**kwargs)
-        bathrooms = self._unit_attributes.get("amenities", {}).get("rooms", {}).get("bathrooms", {})
+        # Guard each step with `or {}` so the chain stays safe when the API
+        # returns explicit None for amenities/rooms/bathrooms instead of omitting them.
+        amenities = self._unit_attributes.get("amenities") or {}
+        rooms = amenities.get("rooms") or {}
+        bathrooms = rooms.get("bathrooms") or {}
         if bathrooms:
             self._bathrooms_value: float | None = (
                 bathrooms.get("full", 0) + bathrooms.get("half", 0) * 0.5
@@ -582,10 +590,10 @@ class VacasaStatementSensor(VacasaApiUpdateMixin, SensorEntity):
         return self._latest.get("attributes", {}) or {}
 
     @property
-    def native_value(self) -> float | int:
-        """Return the latest statement total."""
+    def native_value(self) -> float:
+        """Return the latest statement total in dollars."""
         if not self._latest:
-            return 0
+            return 0.0
 
         attributes = self._latest_attributes()
         for field in ("totalAmount", "netAmount", "balance", "amountDue"):
@@ -593,7 +601,9 @@ class VacasaStatementSensor(VacasaApiUpdateMixin, SensorEntity):
             if amount is not None:
                 return amount
 
-        return len(self._statements)
+        # No usable amount field on the latest statement; report 0.0 rather
+        # than the statement count, which would be meaningless given the "$" unit.
+        return 0.0
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -246,6 +246,15 @@ class CoordinatorEntity:
     async def async_will_remove_from_hass(self):  # pragma: no cover - stub
         return None
 
+    def async_write_ha_state(self):  # pragma: no cover - stub
+        return None
+
+    def _handle_coordinator_update(self):  # pragma: no cover - stub
+        # Mirror Home Assistant's CoordinatorEntity which writes HA state on each
+        # coordinator refresh. Subclasses that override this and call super() rely
+        # on it to push the new state.
+        self.async_write_ha_state()
+
     def __class_getitem__(cls, item):  # pragma: no cover - typing only
         return cls
 

--- a/tests/test_sensor_platform.py
+++ b/tests/test_sensor_platform.py
@@ -208,6 +208,27 @@ def test_bedrooms_sensor_no_amenities():
     assert sensor.extra_state_attributes == {}
 
 
+def test_bedrooms_sensor_null_amenities():
+    """Bedrooms sensor handles amenities/rooms/beds being explicitly None."""
+    sensor = VacasaBedroomsSensor(
+        coordinator=Mock(),
+        unit_id="3",
+        name="Unit",
+        unit_attributes={"amenities": None},
+    )
+    assert sensor.native_value is None
+    assert sensor.extra_state_attributes == {}
+
+    sensor = VacasaBedroomsSensor(
+        coordinator=Mock(),
+        unit_id="3",
+        name="Unit",
+        unit_attributes={"amenities": {"rooms": None, "beds": None}},
+    )
+    assert sensor.native_value is None
+    assert sensor.extra_state_attributes == {}
+
+
 # ---------------------------------------------------------------------------
 # Bathrooms sensor
 # ---------------------------------------------------------------------------
@@ -228,6 +249,27 @@ def test_bathrooms_sensor_values():
 def test_bathrooms_sensor_empty():
     """Bathrooms sensor returns None when bathroom data is absent."""
     sensor = VacasaBathroomsSensor(coordinator=Mock(), unit_id="3", name="Unit", unit_attributes={})
+    assert sensor.native_value is None
+    assert sensor.extra_state_attributes == {}
+
+
+def test_bathrooms_sensor_null_amenities():
+    """Bathrooms sensor handles amenities/rooms/bathrooms being explicitly None."""
+    sensor = VacasaBathroomsSensor(
+        coordinator=Mock(),
+        unit_id="3",
+        name="Unit",
+        unit_attributes={"amenities": None},
+    )
+    assert sensor.native_value is None
+    assert sensor.extra_state_attributes == {}
+
+    sensor = VacasaBathroomsSensor(
+        coordinator=Mock(),
+        unit_id="3",
+        name="Unit",
+        unit_attributes={"amenities": {"rooms": {"bathrooms": None}}},
+    )
     assert sensor.native_value is None
     assert sensor.extra_state_attributes == {}
 
@@ -440,6 +482,18 @@ def test_statement_sensor_no_statements():
     sensor = _make_statement_sensor()
     assert sensor.native_value == 0
     assert sensor._latest_attributes() == {}
+
+
+def test_statement_sensor_returns_zero_when_no_amount_field():
+    """Statement sensor reports 0.0 (not the statement count) when no parseable amount."""
+    sensor = _make_statement_sensor()
+    sensor._statements = [
+        {"id": "s1", "attributes": {"updatedAt": "2024-01-01"}},
+        {"id": "s2", "attributes": {"updatedAt": "2024-02-01", "totalAmount": "not-a-number"}},
+    ]
+    sensor._latest = sensor._latest_statement()
+    # No usable amount field; should return 0.0 rather than len(_statements) == 2.
+    assert sensor.native_value == 0.0
 
 
 def test_statement_sensor_latest_attributes_none():


### PR DESCRIPTION
- VacasaStatementSensor.native_value: return 0.0 (not the statement
  count) when no parseable amount field is present, so the "$" unit is
  always meaningful and the return type stays consistent.
- VacasaBedroomsSensor / VacasaBathroomsSensor: coerce explicit-None
  amenities/rooms/beds/bathrooms to {} so the chained .get() lookups
  no longer raise AttributeError when the API returns null instead of
  omitting the key.
- tests/conftest.py: add async_write_ha_state and
  _handle_coordinator_update stubs to the CoordinatorEntity test stub
  so existing tests can patch them. Without these, three tests in
  test_binary_sensor.py and test_calendar.py raised AttributeError on
  patch.object / super() resolution.
- Add regression tests covering the null-amenity branches and the
  no-amount-field statement-sensor fallback.